### PR TITLE
Feature/86422 exception process entity event

### DIFF
--- a/src/Dfe.Spi.Registry.Application/Matching/Matcher.cs
+++ b/src/Dfe.Spi.Registry.Application/Matching/Matcher.cs
@@ -47,10 +47,10 @@ namespace Dfe.Spi.Registry.Application.Matching
                 var synonymLinks = await GetLinks(synonymousEntity, pointInTime, profiles, cancellationToken);
                 foreach (var synonymLink in synonymLinks)
                 {
-                    if (!links.Any(l => l.LinkType == synonymLink.LinkType &&
-                                        l.Entity.EntityType == synonymLink.Entity.EntityType &&
-                                        l.Entity.SourceSystemName == synonymLink.Entity.SourceSystemName &&
-                                        l.Entity.SourceSystemId == synonymLink.Entity.SourceSystemId))
+                    if (!links.Any(l => l.LinkType.Equals(synonymLink.LinkType, StringComparison.InvariantCultureIgnoreCase) &&
+                                        l.Entity.EntityType.Equals(synonymLink.Entity.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
+                                                                   l.Entity.SourceSystemName.Equals(synonymLink.Entity.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
+                                                                   l.Entity.SourceSystemId.Equals(synonymLink.Entity.SourceSystemId, StringComparison.InvariantCultureIgnoreCase)))
                     {
                         synonymLink.LinkFromSynonym = true;
                         synonymLink.LinkFromSynonym = true;

--- a/src/Dfe.Spi.Registry.Application/Matching/Matcher.cs
+++ b/src/Dfe.Spi.Registry.Application/Matching/Matcher.cs
@@ -47,10 +47,10 @@ namespace Dfe.Spi.Registry.Application.Matching
                 var synonymLinks = await GetLinks(synonymousEntity, pointInTime, profiles, cancellationToken);
                 foreach (var synonymLink in synonymLinks)
                 {
-                    if (!links.Any(l => l.LinkType.Equals(synonymLink.LinkType, StringComparison.InvariantCultureIgnoreCase) &&
-                                        l.Entity.EntityType.Equals(synonymLink.Entity.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
-                                                                   l.Entity.SourceSystemName.Equals(synonymLink.Entity.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
-                                                                   l.Entity.SourceSystemId.Equals(synonymLink.Entity.SourceSystemId, StringComparison.InvariantCultureIgnoreCase)))
+                    if (!links.Any(l => string.Equals(l.LinkType,synonymLink.LinkType, StringComparison.InvariantCultureIgnoreCase) &&
+                                        string.Equals(l.Entity.EntityType,synonymLink.Entity.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
+                                        string.Equals(l.Entity.SourceSystemName,synonymLink.Entity.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
+                                        string.Equals(l.Entity.SourceSystemId,synonymLink.Entity.SourceSystemId, StringComparison.InvariantCultureIgnoreCase)))
                     {
                         synonymLink.LinkFromSynonym = true;
                         synonymLink.LinkFromSynonym = true;
@@ -186,9 +186,9 @@ namespace Dfe.Spi.Registry.Application.Matching
             {
                 var numberOfEntitiesThatAreSourceEntity =
                     candidate.Entities.Count(entity =>
-                        entity.EntityType.Equals(sourceEntity.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
-                        entity.SourceSystemName.Equals(sourceEntity.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
-                        entity.SourceSystemId.Equals(sourceEntity.SourceSystemId, StringComparison.InvariantCultureIgnoreCase));
+                        string.Equals(entity.EntityType,sourceEntity.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
+                        string.Equals(entity.SourceSystemName,sourceEntity.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
+                                      string.Equals(entity.SourceSystemId,sourceEntity.SourceSystemId, StringComparison.InvariantCultureIgnoreCase));
 
                 return candidate.Entities.Length - numberOfEntitiesThatAreSourceEntity > 0;
             }
@@ -292,9 +292,9 @@ namespace Dfe.Spi.Registry.Application.Matching
                 }
 
                 return x != null && y != null &&
-                       x.EntityType.Equals(y.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
-                       x.SourceSystemName.Equals(y.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
-                       x.SourceSystemId.Equals(y.SourceSystemId, StringComparison.InvariantCultureIgnoreCase);
+                       string.Equals(x.EntityType,y.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
+                                     string.Equals(x.SourceSystemName,y.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
+                                                   string.Equals(x.SourceSystemId,y.SourceSystemId, StringComparison.InvariantCultureIgnoreCase);
             }
 
             public int GetHashCode(LinkedEntity obj)

--- a/src/Dfe.Spi.Registry.Application/Matching/Matcher.cs
+++ b/src/Dfe.Spi.Registry.Application/Matching/Matcher.cs
@@ -59,6 +59,16 @@ namespace Dfe.Spi.Registry.Application.Matching
                 }
             }
 
+            // making sure SourceSystemName is always in uppercase
+            links.ForEach(x => x.Entity.SourceSystemName = x.Entity.SourceSystemName.ToUpper());
+            links.ForEach(x =>
+            {
+                foreach (var t in x.RegisteredEntity.Links)
+                {
+                    t.SourceSystemName = t.SourceSystemName.ToUpper();
+                }
+            });
+
             return new MatchResult
             {
                 Synonyms = synonyms.ToArray(),

--- a/src/Dfe.Spi.Registry.Application/Sync/SyncManager.cs
+++ b/src/Dfe.Spi.Registry.Application/Sync/SyncManager.cs
@@ -390,7 +390,7 @@ namespace Dfe.Spi.Registry.Application.Sync
 
             foreach (var entity1 in registeredEntity1.Entities)
             {
-                var entity2 = registeredEntity2.Entities.SingleOrDefault(e2 =>
+                var entity2 = registeredEntity2.Entities.FirstOrDefault(e2 =>
                     string.Equals(e2.SourceSystemName,entity1.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
                     string.Equals(e2.SourceSystemId,entity1.SourceSystemId, StringComparison.InvariantCultureIgnoreCase));
 
@@ -416,7 +416,7 @@ namespace Dfe.Spi.Registry.Application.Sync
 
             foreach (var link1 in registeredEntity1.Links ?? new Link[] { })
             {
-                var link2 = registeredEntity2.Links.SingleOrDefault(l2 =>
+                var link2 = registeredEntity2.Links.FirstOrDefault(l2 =>
                     string.Equals(l2.EntityType,link1.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
                                   string.Equals(l2.SourceSystemName,link1.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
                                                 string.Equals(l2.SourceSystemId,link1.SourceSystemId, StringComparison.InvariantCultureIgnoreCase) &&

--- a/src/Dfe.Spi.Registry.Application/Sync/SyncManager.cs
+++ b/src/Dfe.Spi.Registry.Application/Sync/SyncManager.cs
@@ -403,13 +403,13 @@ namespace Dfe.Spi.Registry.Application.Sync
             }
 
             // Compare links
-            if (registeredEntity1.Links.Length != registeredEntity2.Links.Length)
+            if ((registeredEntity1.Links?.Length ?? 0) != (registeredEntity2.Links?.Length ?? 0))
             {
                 _logger.Debug($"Entity {registeredEntity1.Id} and {registeredEntity2.Id} have a different number of links");
                 return false;
             }
 
-            foreach (var link1 in registeredEntity1.Links)
+            foreach (var link1 in registeredEntity1.Links ?? new Link[] { })
             {
                 var link2 = registeredEntity2.Links.SingleOrDefault(l2 =>
                     string.Equals(l2.EntityType,link1.EntityType, StringComparison.InvariantCultureIgnoreCase) &&

--- a/src/Dfe.Spi.Registry.Application/Sync/SyncManager.cs
+++ b/src/Dfe.Spi.Registry.Application/Sync/SyncManager.cs
@@ -166,7 +166,7 @@ namespace Dfe.Spi.Registry.Application.Sync
             _logger.Debug($"Preparing updated version of {entity} at {pointInTime}");
 
             // Get entities
-            var entities = new List<LinkedEntity>(new[] {MapEntityToLinkedEntity(entity)});
+            var entities = new List<LinkedEntity>(new[] { MapEntityToLinkedEntity(entity) });
             if (matchResult.Synonyms.Length > 0)
             {
                 entities[0].LinkedAt = DateTime.UtcNow;
@@ -258,7 +258,7 @@ namespace Dfe.Spi.Registry.Application.Sync
                              $"{existingEntity.ValidFrom} ({existingEntity.Id}). No update being made");
                 return;
             }
-            
+
             // Check if any synonyms of original entity are now unlinked
             if (existingEntity != null)
             {
@@ -311,9 +311,9 @@ namespace Dfe.Spi.Registry.Application.Sync
             foreach (var link in linksToUpdate)
             {
                 var linkFromUpdate = updatedEntity.Links.Single(updateLink =>
-                    updateLink.EntityType == link.Entity.EntityType &&
-                    updateLink.SourceSystemName == link.Entity.SourceSystemName &&
-                    updateLink.SourceSystemId == link.Entity.SourceSystemId);
+                    updateLink.EntityType.Equals(link.Entity.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
+                    updateLink.SourceSystemName.Equals(link.Entity.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
+                    updateLink.SourceSystemId.Equals(link.Entity.SourceSystemId, StringComparison.InvariantCultureIgnoreCase));
                 var newLink = new Link
                 {
                     EntityType = updatedEntity.Entities[0].EntityType,
@@ -368,10 +368,10 @@ namespace Dfe.Spi.Registry.Application.Sync
 
         private bool AreAlreadyLinked(Entity sourceEntity, string linkType, RegisteredEntity entityBeingLinkedTo)
         {
-            return entityBeingLinkedTo.Links.Any(link => link.LinkType == linkType &&
-                                                         link.EntityType == sourceEntity.EntityType &&
-                                                         link.SourceSystemName == sourceEntity.SourceSystemName &&
-                                                         link.SourceSystemId == sourceEntity.SourceSystemId);
+            return entityBeingLinkedTo.Links.Any(link => link.LinkType.Equals(linkType, StringComparison.InvariantCultureIgnoreCase) &&
+                                                         link.EntityType.Equals(sourceEntity.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
+                                                         link.SourceSystemName.Equals(sourceEntity.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
+                                                         link.SourceSystemId.Equals(sourceEntity.SourceSystemId, StringComparison.InvariantCultureIgnoreCase));
         }
 
         private bool AreSame(RegisteredEntity registeredEntity1, RegisteredEntity registeredEntity2)
@@ -386,8 +386,8 @@ namespace Dfe.Spi.Registry.Application.Sync
             foreach (var entity1 in registeredEntity1.Entities)
             {
                 var entity2 = registeredEntity2.Entities.SingleOrDefault(e2 =>
-                    e2.SourceSystemName == entity1.SourceSystemName &&
-                    e2.SourceSystemId == entity1.SourceSystemId);
+                    e2.SourceSystemName.Equals(entity1.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
+                                               e2.SourceSystemId.Equals(entity1.SourceSystemId, StringComparison.InvariantCultureIgnoreCase));
 
                 if (entity2 == null)
                 {
@@ -412,10 +412,10 @@ namespace Dfe.Spi.Registry.Application.Sync
             foreach (var link1 in registeredEntity1.Links)
             {
                 var link2 = registeredEntity2.Links.SingleOrDefault(l2 =>
-                    l2.EntityType == link1.EntityType &&
-                    l2.SourceSystemName == link1.SourceSystemName &&
-                    l2.SourceSystemId == link1.SourceSystemId &&
-                    l2.LinkType == link1.LinkType);
+                    l2.EntityType.Equals(link1.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
+                    l2.SourceSystemName.Equals(link1.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
+                    l2.SourceSystemId.Equals(link1.SourceSystemId, StringComparison.InvariantCultureIgnoreCase) &&
+                    l2.LinkType.Equals(link1.LinkType, StringComparison.InvariantCultureIgnoreCase));
 
                 if (link2 == null)
                 {
@@ -430,15 +430,15 @@ namespace Dfe.Spi.Registry.Application.Sync
 
         private bool AreSame(Entity entity1, Entity entity2)
         {
-            return entity1.Name == entity2.Name &&
-                   entity1.Type == entity2.Type &&
-                   entity1.SubType == entity2.SubType &&
-                   entity1.Status == entity2.Status &&
+            return entity1.Name.Equals(entity2.Name, StringComparison.InvariantCultureIgnoreCase) &&
+                   entity1.Type.Equals(entity2.Type, StringComparison.InvariantCultureIgnoreCase) &&
+                   entity1.SubType.Equals(entity2.SubType, StringComparison.InvariantCultureIgnoreCase) &&
+                   entity1.Status.Equals(entity2.Status, StringComparison.InvariantCultureIgnoreCase) &&
                    entity1.OpenDate == entity2.OpenDate &&
                    entity1.CloseDate == entity2.CloseDate &&
                    entity1.Urn == entity2.Urn &&
                    entity1.Ukprn == entity2.Ukprn &&
-                   entity1.Uprn == entity2.Uprn &&
+                   entity1.Uprn.Equals(entity2.Uprn, StringComparison.InvariantCultureIgnoreCase) &&
                    entity1.CompaniesHouseNumber == entity2.CompaniesHouseNumber &&
                    entity1.CharitiesCommissionNumber == entity2.CharitiesCommissionNumber &&
                    entity1.AcademyTrustCode == entity2.AcademyTrustCode &&

--- a/src/Dfe.Spi.Registry.Application/Sync/SyncManager.cs
+++ b/src/Dfe.Spi.Registry.Application/Sync/SyncManager.cs
@@ -90,7 +90,7 @@ namespace Dfe.Spi.Registry.Application.Sync
                 return new Entity
                 {
                     EntityType = EntityNameTranslator.LearningProviderSingular,
-                    SourceSystemName = sourceSystemName,
+                    SourceSystemName = sourceSystemName.ToUpper(),
                     SourceSystemId = sourceSystemId,
                     Name = learningProvider.Name,
                     Type = learningProvider.Type,

--- a/src/Dfe.Spi.Registry.Application/Sync/SyncManager.cs
+++ b/src/Dfe.Spi.Registry.Application/Sync/SyncManager.cs
@@ -311,9 +311,9 @@ namespace Dfe.Spi.Registry.Application.Sync
             foreach (var link in linksToUpdate)
             {
                 var linkFromUpdate = updatedEntity.Links.Single(updateLink =>
-                    updateLink.EntityType.Equals(link.Entity.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
-                    updateLink.SourceSystemName.Equals(link.Entity.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
-                    updateLink.SourceSystemId.Equals(link.Entity.SourceSystemId, StringComparison.InvariantCultureIgnoreCase));
+                    string.Equals(updateLink.EntityType,link.Entity.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
+                    string.Equals(updateLink.SourceSystemName,link.Entity.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
+                    string.Equals(updateLink.SourceSystemId,link.Entity.SourceSystemId, StringComparison.InvariantCultureIgnoreCase));
                 var newLink = new Link
                 {
                     EntityType = updatedEntity.Entities[0].EntityType,
@@ -368,10 +368,10 @@ namespace Dfe.Spi.Registry.Application.Sync
 
         private bool AreAlreadyLinked(Entity sourceEntity, string linkType, RegisteredEntity entityBeingLinkedTo)
         {
-            return entityBeingLinkedTo.Links.Any(link => link.LinkType.Equals(linkType, StringComparison.InvariantCultureIgnoreCase) &&
-                                                         link.EntityType.Equals(sourceEntity.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
-                                                         link.SourceSystemName.Equals(sourceEntity.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
-                                                         link.SourceSystemId.Equals(sourceEntity.SourceSystemId, StringComparison.InvariantCultureIgnoreCase));
+            return entityBeingLinkedTo.Links.Any(link => string.Equals(link.LinkType,linkType, StringComparison.InvariantCultureIgnoreCase) &&
+                                                         string.Equals(link.EntityType,sourceEntity.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
+                                                         string.Equals(link.SourceSystemName,sourceEntity.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
+                                                         string.Equals(link.SourceSystemId,sourceEntity.SourceSystemId, StringComparison.InvariantCultureIgnoreCase));
         }
 
         private bool AreSame(RegisteredEntity registeredEntity1, RegisteredEntity registeredEntity2)
@@ -386,8 +386,8 @@ namespace Dfe.Spi.Registry.Application.Sync
             foreach (var entity1 in registeredEntity1.Entities)
             {
                 var entity2 = registeredEntity2.Entities.SingleOrDefault(e2 =>
-                    e2.SourceSystemName.Equals(entity1.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
-                                               e2.SourceSystemId.Equals(entity1.SourceSystemId, StringComparison.InvariantCultureIgnoreCase));
+                    string.Equals(e2.SourceSystemName,entity1.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
+                    string.Equals(e2.SourceSystemId,entity1.SourceSystemId, StringComparison.InvariantCultureIgnoreCase));
 
                 if (entity2 == null)
                 {
@@ -412,10 +412,10 @@ namespace Dfe.Spi.Registry.Application.Sync
             foreach (var link1 in registeredEntity1.Links)
             {
                 var link2 = registeredEntity2.Links.SingleOrDefault(l2 =>
-                    l2.EntityType.Equals(link1.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
-                    l2.SourceSystemName.Equals(link1.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
-                    l2.SourceSystemId.Equals(link1.SourceSystemId, StringComparison.InvariantCultureIgnoreCase) &&
-                    l2.LinkType.Equals(link1.LinkType, StringComparison.InvariantCultureIgnoreCase));
+                    string.Equals(l2.EntityType,link1.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
+                                  string.Equals(l2.SourceSystemName,link1.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
+                                                string.Equals(l2.SourceSystemId,link1.SourceSystemId, StringComparison.InvariantCultureIgnoreCase) &&
+                                                              string.Equals(l2.LinkType,link1.LinkType, StringComparison.InvariantCultureIgnoreCase));
 
                 if (link2 == null)
                 {
@@ -430,25 +430,26 @@ namespace Dfe.Spi.Registry.Application.Sync
 
         private bool AreSame(Entity entity1, Entity entity2)
         {
-            return entity1.Name.Equals(entity2.Name, StringComparison.InvariantCultureIgnoreCase) &&
-                   entity1.Type.Equals(entity2.Type, StringComparison.InvariantCultureIgnoreCase) &&
-                   entity1.SubType.Equals(entity2.SubType, StringComparison.InvariantCultureIgnoreCase) &&
-                   entity1.Status.Equals(entity2.Status, StringComparison.InvariantCultureIgnoreCase) &&
+            return string.Equals(entity1.Name, entity2.Name, StringComparison.InvariantCultureIgnoreCase) &&
+                   string.Equals(entity1.Type, entity2.Type, StringComparison.InvariantCultureIgnoreCase) &&
+                   string.Equals(entity1.SubType, entity2.SubType, StringComparison.InvariantCultureIgnoreCase) &&
+                   string.Equals(entity1.Status, entity2.Status, StringComparison.InvariantCultureIgnoreCase) &&
                    entity1.OpenDate == entity2.OpenDate &&
                    entity1.CloseDate == entity2.CloseDate &&
                    entity1.Urn == entity2.Urn &&
                    entity1.Ukprn == entity2.Ukprn &&
-                   entity1.Uprn.Equals(entity2.Uprn, StringComparison.InvariantCultureIgnoreCase) &&
-                   entity1.CompaniesHouseNumber == entity2.CompaniesHouseNumber &&
-                   entity1.CharitiesCommissionNumber == entity2.CharitiesCommissionNumber &&
-                   entity1.AcademyTrustCode == entity2.AcademyTrustCode &&
-                   entity1.DfeNumber == entity2.DfeNumber &&
-                   entity1.LocalAuthorityCode == entity2.LocalAuthorityCode &&
-                   entity1.ManagementGroupType == entity2.ManagementGroupType &&
-                   entity1.ManagementGroupId == entity2.ManagementGroupId &&
-                   entity1.ManagementGroupCode == entity2.ManagementGroupCode &&
-                   entity1.ManagementGroupUkprn == entity2.ManagementGroupUkprn &&
-                   entity1.ManagementGroupCompaniesHouseNumber == entity2.ManagementGroupCompaniesHouseNumber;
+                   string.Equals(entity1.Uprn, entity2.Uprn, StringComparison.InvariantCultureIgnoreCase) &&
+                     entity1.CompaniesHouseNumber == entity2.CompaniesHouseNumber &&
+                     entity1.CharitiesCommissionNumber == entity2.CharitiesCommissionNumber &&
+                     entity1.AcademyTrustCode == entity2.AcademyTrustCode &&
+                     entity1.DfeNumber == entity2.DfeNumber &&
+                     entity1.LocalAuthorityCode == entity2.LocalAuthorityCode &&
+                     entity1.ManagementGroupType == entity2.ManagementGroupType &&
+                     entity1.ManagementGroupId == entity2.ManagementGroupId &&
+                     entity1.ManagementGroupCode == entity2.ManagementGroupCode &&
+                     entity1.ManagementGroupUkprn == entity2.ManagementGroupUkprn &&
+                     entity1.ManagementGroupCompaniesHouseNumber == entity2.ManagementGroupCompaniesHouseNumber;
         }
+
     }
 }

--- a/src/Dfe.Spi.Registry.Application/Sync/SyncManager.cs
+++ b/src/Dfe.Spi.Registry.Application/Sync/SyncManager.cs
@@ -308,9 +308,14 @@ namespace Dfe.Spi.Registry.Application.Sync
                 .Where(link => !link.LinkFromSynonym &&
                                !AreAlreadyLinked(updatedEntity.Entities[0], link.LinkType, link.RegisteredEntity))
                 .ToArray();
+
+            _logger.Info($"Links to update {linksToUpdate.Length}");
+
             foreach (var link in linksToUpdate)
             {
-                var linkFromUpdate = updatedEntity.Links.Single(updateLink =>
+                _logger.Info($"Link to update {link.Entity.SourceSystemId}, {link.Entity.SourceSystemName}, {link.Entity.EntityType}");
+
+                var linkFromUpdate = updatedEntity.Links.FirstOrDefault(updateLink =>
                     string.Equals(updateLink.EntityType,link.Entity.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
                     string.Equals(updateLink.SourceSystemName,link.Entity.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
                     string.Equals(updateLink.SourceSystemId,link.Entity.SourceSystemId, StringComparison.InvariantCultureIgnoreCase));
@@ -319,10 +324,10 @@ namespace Dfe.Spi.Registry.Application.Sync
                     EntityType = updatedEntity.Entities[0].EntityType,
                     SourceSystemName = updatedEntity.Entities[0].SourceSystemName,
                     SourceSystemId = updatedEntity.Entities[0].SourceSystemId,
-                    LinkedAt = linkFromUpdate.LinkedAt,
-                    LinkedBy = linkFromUpdate.LinkedBy,
-                    LinkedReason = linkFromUpdate.LinkedReason,
-                    LinkType = linkFromUpdate.LinkType,
+                    LinkedAt = linkFromUpdate?.LinkedAt ?? DateTime.Now,
+                    LinkedBy = linkFromUpdate?.LinkedBy,
+                    LinkedReason = linkFromUpdate?.LinkedReason,
+                    LinkType = linkFromUpdate?.LinkType,
                 };
 
                 var updatedLinkedEntity = CloneWithNewLink(link.RegisteredEntity, newLink, updatedEntity.ValidFrom);

--- a/src/Dfe.Spi.Registry.Application/Sync/SyncManager.cs
+++ b/src/Dfe.Spi.Registry.Application/Sync/SyncManager.cs
@@ -319,16 +319,16 @@ namespace Dfe.Spi.Registry.Application.Sync
                     string.Equals(updateLink.EntityType,link.Entity.EntityType, StringComparison.InvariantCultureIgnoreCase) &&
                     string.Equals(updateLink.SourceSystemName,link.Entity.SourceSystemName, StringComparison.InvariantCultureIgnoreCase) &&
                     string.Equals(updateLink.SourceSystemId,link.Entity.SourceSystemId, StringComparison.InvariantCultureIgnoreCase));
-                var newLink = new Link
+                var newLink = linkFromUpdate != null ? new Link
                 {
                     EntityType = updatedEntity.Entities[0].EntityType,
                     SourceSystemName = updatedEntity.Entities[0].SourceSystemName,
                     SourceSystemId = updatedEntity.Entities[0].SourceSystemId,
-                    LinkedAt = linkFromUpdate?.LinkedAt ?? DateTime.Now,
-                    LinkedBy = linkFromUpdate?.LinkedBy,
-                    LinkedReason = linkFromUpdate?.LinkedReason,
-                    LinkType = linkFromUpdate?.LinkType,
-                };
+                    LinkedAt = linkFromUpdate.LinkedAt,
+                    LinkedBy = linkFromUpdate.LinkedBy,
+                    LinkedReason = linkFromUpdate.LinkedReason,
+                    LinkType = linkFromUpdate.LinkType,
+                } : null;
 
                 var updatedLinkedEntity = CloneWithNewLink(link.RegisteredEntity, newLink, updatedEntity.ValidFrom);
                 updates.Add(updatedLinkedEntity);
@@ -363,11 +363,11 @@ namespace Dfe.Spi.Registry.Application.Sync
                 Type = registeredEntity.Type,
                 ValidFrom = validFrom,
                 Entities = registeredEntity.Entities,
-                Links = registeredEntity.Links.Concat(
+                Links = newLink != null ? registeredEntity.Links.Concat(
                     new[]
                     {
                         newLink
-                    }).ToArray(),
+                    }).ToArray() : registeredEntity.Links,
             };
         }
 


### PR DESCRIPTION
- Eliminating duplicate links by making sure consistent casing of SourceSystemName and string comparisons with ignored case.
- Fixing "Sequence contains more than one matching element" error by changing SingleOrDefault linq extension to FirstOrDefault and handling nulls to support lists with more than one item!
